### PR TITLE
Parse integers without heap allocations

### DIFF
--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -5,8 +5,10 @@ require "../src/parser"
 module Redis
   describe Parser do
     it "reads ints" do
-      io = IO::Memory.new(":1234\r\n")
-      Parser.new(io).read.should eq 1234
+      [1, 12, 1234, 12345678, 123456789012345678_i64, -1, -12345678, 0].each do |int|
+        io = IO::Memory.new(":#{int}\r\n")
+        Parser.new(io).read.should eq int
+      end
     end
 
     it "reads simple strings" do

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -52,7 +52,8 @@ describe Redis::Client do
 
       redis.incrby(key, 2).should eq 2
       redis.incrby(key, 3).should eq 5
-      redis.decrby(key, 2)
+      redis.decrby(key, 2).should eq 3
+      redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
 
     ensure
       redis.del key


### PR DESCRIPTION
This PR extracts integer parsing to a separate method and removes the intermediate heap allocations associated with `read_line.to_i64`.

In the benchmark I ran for [my blog post](https://dev.to/jgaskins/performance-comparison-rust-vs-crystal-with-redis-1a17):

```
bin/bench_redis  0.12s user 0.02s system 41% cpu 0.341 total
```

With this change:

```
bin/bench_redis  0.10s user 0.02s system 35% cpu 0.332 total
```

We're down from 14ms of CPU time for that benchmark to 12, so we should see a 17% throughput improvement for these kinds of operations.