### PR TITLE
fix initialize redis client without params

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -22,7 +22,7 @@ module Redis
     # Password authentication uses the URI password.
     # DB selection uses the URI path.
     def initialize(@uri = URI.parse("redis:///"))
-      host = uri.host || "localhost"
+      host = uri.host.presence || "localhost"
       port = uri.port || 6379
       socket = TCPSocket.new(host, port)
       socket.sync = false


### PR DESCRIPTION
`Redis::Client.new` w/o params always fails with

```
Hostname lookup for  failed: No address found (Socket::Addrinfo::Error)
```

Why?

```
require "uri"
 
URI.parse("redis:///")
=> #<URI:0x7f68c432cf60 @scheme="redis", @host="", @port=nil, @path="/", @query=nil, @user=nil, @password=nil, @fragment=nil>
```