### PR TITLE
Allow global style client connection via Redis.current

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ redis.decr "counter" # => 1
 redis.del "foo", "counter" # => 2
 ```
 
+(Optional) Set a global current client with `Redis.current`
+
+```crystal
+require "redis"
+
+Redis.current = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")))
+
+# call it somewhere in the app
+def redis
+  Redis.current
+end
+
+# or
+
+redis = Redis.current
+```
+> Note: Setting `Redis.current` can only happen once to avoid accidental override
+
 ### Pipelined queries
 
 To mitigate latency with multiple queries whose inputs and outputs are completely independent of each other, you can "pipeline" your queries by sending them all at once before reading them. To do this, you can use the `pipeline` method:

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -377,15 +377,18 @@ describe Redis::Client do
 
   describe "current" do
     it "allows setting current once and response to Redis.current" do
-      (Redis.current).should eq(nil)
+      (Redis.current).should be_a(Redis::Client)
 
       client = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis:///")))
       Redis.current = client
 
       (Redis.current).should eq(client)
 
-      new_client = Redis.current = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")))
-      Redis.current = new_client
+      new_client = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")))
+
+      expect_raises ArgumentError, "Warning! `Redis.current =` can only be set once to avoid accidental override" do
+        Redis.current = new_client
+      end
 
       (Redis.current).should eq(client)
     end

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -84,7 +84,6 @@ describe Redis::Client do
       redis.incrby(key, 3).should eq 5
       redis.decrby(key, 2).should eq 3
       redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
-
     ensure
       redis.del key
     end
@@ -156,9 +155,9 @@ describe Redis::Client do
     key = random_key
 
     begin
-      first_incr  = Redis::Future.new
+      first_incr = Redis::Future.new
       second_incr = Redis::Future.new
-      first_decr  = Redis::Future.new
+      first_decr = Redis::Future.new
       second_decr = Redis::Future.new
 
       redis.pipeline do |redis|
@@ -266,7 +265,6 @@ describe Redis::Client do
         consumer_id = UUID.random.to_s
 
         result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
-
       rescue ex
         pp ex
         raise ex
@@ -374,6 +372,22 @@ describe Redis::Client do
         # Only set ready if *both* subscriptions have gone through
         ready = true if count == 2
       end
+    end
+  end
+
+  describe "current" do
+    it "allows setting current once and response to Redis.current" do
+      (Redis.current).should eq(nil)
+
+      client = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis:///")))
+      Redis.current = client
+
+      (Redis.current).should eq(client)
+
+      new_client = Redis.current = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")))
+      Redis.current = new_client
+
+      (Redis.current).should eq(client)
     end
   end
 end

--- a/src/client.cr
+++ b/src/client.cr
@@ -3,6 +3,30 @@ require "db/pool"
 require "./connection"
 
 module Redis
+  # Set a global current client
+  #
+  # Example
+  # ```
+  # Redis.current = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")))
+  #
+  # # somewhere in the app
+  # def redis
+  #   Redis.current
+  # end
+  #
+  # # or just use a simple local scope
+  #
+  # redis = Redis.current
+  # ```
+  # > Note: Setting `Redis.current` can only happen once to avoid accidental override
+  def self.current=(client : Redis::Client)
+    @@current ||= client
+  end
+
+  def self.current
+    @@current
+  end
+
   # The Redis client is the expected entrypoint for this shard. By default, it will connect to localhost:6379, but you can also supply a `URI` to connect to an arbitrary Redis server. SSL, password authentication, and DB selection are all supported.
   #
   # ```

--- a/src/client.cr
+++ b/src/client.cr
@@ -20,11 +20,12 @@ module Redis
   # ```
   # > Note: Setting `Redis.current` can only happen once to avoid accidental override
   def self.current=(client : Redis::Client)
-    @@current ||= client
+    raise ArgumentError.new("Warning! `Redis.current =` can only be set once to avoid accidental override") if @@current
+    @@current = client
   end
 
-  def self.current
-    @@current
+  def self.current : Redis::Client
+    @@current || Redis::Client.new
   end
 
   # The Redis client is the expected entrypoint for this shard. By default, it will connect to localhost:6379, but you can also supply a `URI` to connect to an arbitrary Redis server. SSL, password authentication, and DB selection are all supported.


### PR DESCRIPTION
Allow global access to the current client via `Redis.current`

Example

```crystal
Redis.current = Redis::Client.new(URI.parse(ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")))
```

Setting `Redis.current` can only happen once to avoid accidental override