### PR TITLE
Adding the zcount command.

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -191,6 +191,42 @@ describe Redis::Client do
     end
   end
 
+  describe "sorted sets" do
+    it "can add and remove members of a sorted set" do
+      key = random_key
+
+      begin
+        redis.zadd(key, "1", "a").should eq 1
+        redis.zadd(key, "1", "a").should eq 0
+        redis.zrange(key, "0", "-1").should eq %w[a]
+
+        redis.zadd key, "2", "b"
+        redis.zrange(key, "0", "-1").as(Array).should contain "a"
+        redis.zrange(key, "0", "-1").as(Array).should contain "b"
+
+        redis.zrem key, "a"
+        redis.zrange(key, "0", "-1").as(Array).should_not contain "a"
+        redis.zrange(key, "0", "-1").as(Array).should contain "b"
+      ensure
+        redis.del key
+      end
+    end
+
+    it "counts the number of elements set at the key" do
+      key = random_key
+
+      begin
+        redis.zadd(key, "1", "one")
+        redis.zadd(key, "2", "two")
+        redis.zadd(key, "3", "three")
+        redis.zcount(key, "0", "+inf").should eq(3)
+        redis.zcount(key, "(1", "3").should eq(2)
+      ensure
+        redis.del key
+      end
+    end
+  end
+
   it "can pipeline commands" do
     key = random_key
 

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -192,38 +192,26 @@ describe Redis::Client do
   end
 
   describe "sorted sets" do
-    it "can add and remove members of a sorted set" do
-      key = random_key
+    test "can add and remove members of a sorted set" do
+      redis.zadd(key, "1", "a").should eq 1
+      redis.zadd(key, "1", "a").should eq 0
+      redis.zrange(key, "0", "-1").should eq %w[a]
 
-      begin
-        redis.zadd(key, "1", "a").should eq 1
-        redis.zadd(key, "1", "a").should eq 0
-        redis.zrange(key, "0", "-1").should eq %w[a]
+      redis.zadd key, "2", "b"
+      redis.zrange(key, "0", "-1").as(Array).should contain "a"
+      redis.zrange(key, "0", "-1").as(Array).should contain "b"
 
-        redis.zadd key, "2", "b"
-        redis.zrange(key, "0", "-1").as(Array).should contain "a"
-        redis.zrange(key, "0", "-1").as(Array).should contain "b"
-
-        redis.zrem key, "a"
-        redis.zrange(key, "0", "-1").as(Array).should_not contain "a"
-        redis.zrange(key, "0", "-1").as(Array).should contain "b"
-      ensure
-        redis.del key
-      end
+      redis.zrem key, "a"
+      redis.zrange(key, "0", "-1").as(Array).should_not contain "a"
+      redis.zrange(key, "0", "-1").as(Array).should contain "b"
     end
 
-    it "counts the number of elements set at the key" do
-      key = random_key
-
-      begin
-        redis.zadd(key, "1", "one")
-        redis.zadd(key, "2", "two")
-        redis.zadd(key, "3", "three")
-        redis.zcount(key, "0", "+inf").should eq(3)
-        redis.zcount(key, "(1", "3").should eq(2)
-      ensure
-        redis.del key
-      end
+    test "counts the number of elements set at the key" do
+      redis.zadd(key, "1", "one")
+      redis.zadd(key, "2", "two")
+      redis.zadd(key, "3", "three")
+      redis.zcount(key, "0", "+inf").should eq(3)
+      redis.zcount(key, "(1", "3").should eq(2)
     end
   end
 

--- a/src/commands/sorted_set.cr
+++ b/src/commands/sorted_set.cr
@@ -54,4 +54,8 @@ module Redis::Commands::SortedSet
   def zrem(key : String, value : String)
     run({"zrem", key, value})
   end
+
+  def zcount(key : String, min : String, max : String)
+    run({"zcount", key, min, max})
+  end
 end


### PR DESCRIPTION
Fixes #17

This adds the ZCOUNT command. I just followed what the other methods were doing. I noticed there were no specs around sorted sets, so I added some. These two specs pass for me locally; however, all of the `TimeSeries` specs fail... 