### PR TITLE
this method was defined twice. Just removing the second one.

### DIFF
--- a/src/commands/hash.cr
+++ b/src/commands/hash.cr
@@ -24,10 +24,6 @@ module Redis::Commands::Hash
     run({"hset", key} + fields)
   end
 
-  def hset(key : String, *fields : String)
-    run({"hset", key} + fields)
-  end
-
   def hset(key : String, data : ::Hash(String, String))
     command = Array(String).new(initial_capacity: 2 + data.size)
 


### PR DESCRIPTION
Fixes #14

This method was just defined twice. This removes the second copy.