### PR TITLE
Allow connection pooling and tcp connection params

### DIFF
--- a/spec/client_spec.cr
+++ b/spec/client_spec.cr
@@ -1,0 +1,93 @@
+require "./spec_helper"
+require "uuid"
+
+require "../src/client"
+
+module Redis
+  describe Client do
+    it "allows kitchen sink params" do
+      pool_params = "?initial_pool_size=2&max_pool_size=10&checkout_timeout=10&retry_attempts=2&retry_delay=0.5&max_idle_pool_size=50"
+      keepalive_params = "&keepalive=true&keepalive_count=5&keepalive_idle=10&keepalive_interval=15"
+      redis = Client.new(URI.parse("redis://localhost:6379/0#{pool_params}#{keepalive_params}"))
+
+      redis.get "foo"
+
+      redis.@pool.@initial_pool_size.should eq(2)
+      redis.@pool.@max_pool_size.should eq(10)
+      redis.@pool.@checkout_timeout.should eq(10)
+      redis.@pool.@retry_attempts.should eq(2)
+      redis.@pool.@retry_delay.should eq(0.5)
+      redis.@pool.@max_idle_pool_size.should eq(50)
+
+      redis.@pool.checkout.@socket.as(TCPSocket).keepalive?.should eq(true)
+      redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_count.should eq(5)
+      redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(10)
+      redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(15)
+    end
+
+    context "with pool params" do
+      it "uses standard pool args" do
+        redis = Client.new
+
+        redis.get "foo"
+
+        redis.@pool.@initial_pool_size.should eq(1)
+        redis.@pool.@max_pool_size.should eq(0)
+        redis.@pool.@checkout_timeout.should eq(5.0)
+        redis.@pool.@retry_attempts.should eq(1)
+        redis.@pool.@retry_delay.should eq(0.2)
+        redis.@pool.@max_idle_pool_size.should eq(25)
+      end
+
+      it "allowing standard pool args" do
+        pool_params = "?initial_pool_size=2&max_pool_size=10&checkout_timeout=10&retry_attempts=2&retry_delay=0.5&max_idle_pool_size=50"
+        redis = Client.new(URI.parse("redis://localhost:6379/0#{pool_params}"))
+
+        redis.get "foo"
+
+        redis.@pool.@initial_pool_size.should eq(2)
+        redis.@pool.@max_pool_size.should eq(10)
+        redis.@pool.@checkout_timeout.should eq(10)
+        redis.@pool.@retry_attempts.should eq(2)
+        redis.@pool.@retry_delay.should eq(0.5)
+        redis.@pool.@max_idle_pool_size.should eq(50)
+      end
+    end
+
+    context "with keepalive" do
+      it "does nothing if nothing passed" do
+        redis = Client.new(URI.parse("redis://localhost:6379"))
+
+        redis.get "foo"
+
+        redis.@pool.checkout.@socket.as(TCPSocket).keepalive?.should eq(false)
+        # system default settings
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_count.should eq(8)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(7200)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(75)
+      end
+
+      it "accepts settings" do
+        redis = Client.new(URI.parse("redis://localhost:6379?keepalive=true&keepalive_count=5&keepalive_idle=10&keepalive_interval=15"))
+
+        redis.get "foo"
+
+        redis.@pool.checkout.@socket.as(TCPSocket).keepalive?.should eq(true)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_count.should eq(5)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(10)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(15)
+      end
+
+      it "uses default shard keepalive settings" do
+        redis = Client.new(URI.parse("redis://localhost:6379?keepalive=true"))
+
+        redis.get "foo"
+
+        redis.@pool.checkout.@socket.as(TCPSocket).keepalive?.should eq(true)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_count.should eq(3)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(60)
+        redis.@pool.checkout.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(30)
+      end
+    end
+  end
+end

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -38,5 +38,41 @@ module Redis
 
       redis.del key
     end
+
+    context "with keepalive" do
+      it "does nothing if nothing passed" do
+        redis = Connection.new(URI.parse("redis://localhost:6379"))
+
+        redis.get "foo"
+
+        redis.@socket.as(TCPSocket).keepalive?.should eq(false)
+        # system default settings
+        redis.@socket.as(TCPSocket).tcp_keepalive_count.should eq(8)
+        redis.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(7200)
+        redis.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(75)
+      end
+
+      it "accepts settings" do
+        redis = Connection.new(URI.parse("redis://localhost:6379?keepalive=true&keepalive_count=5&keepalive_idle=10&keepalive_interval=15"))
+
+        redis.get "foo"
+
+        redis.@socket.as(TCPSocket).keepalive?.should eq(true)
+        redis.@socket.as(TCPSocket).tcp_keepalive_count.should eq(5)
+        redis.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(10)
+        redis.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(15)
+      end
+
+      it "uses default shard keepalive settings" do
+        redis = Connection.new(URI.parse("redis://localhost:6379?keepalive=true"))
+
+        redis.get "foo"
+
+        redis.@socket.as(TCPSocket).keepalive?.should eq(true)
+        redis.@socket.as(TCPSocket).tcp_keepalive_count.should eq(3)
+        redis.@socket.as(TCPSocket).tcp_keepalive_idle.should eq(60)
+        redis.@socket.as(TCPSocket).tcp_keepalive_interval.should eq(30)
+      end
+    end
   end
 end

--- a/src/client.cr
+++ b/src/client.cr
@@ -26,10 +26,26 @@ module Redis
     # The client holds a pool of connections that expands and contracts as
     # needed.
     def initialize(uri : URI = URI.parse(ENV.fetch("REDIS_URL", "redis:///")))
-      max_idle_pool_size = uri.query_params.fetch("max_idle_pool_size", "25").to_i
+      # defaults as per https://github.com/crystal-lang/crystal-db/blob/v0.11.0/src/db/pool.cr
+      initial_pool_size = uri.query_params.fetch("initial_pool_size", 1).to_i
+      max_pool_size = uri.query_params.fetch("max_pool_size", 0).to_i
+      checkout_timeout = uri.query_params.fetch("checkout_timeout", 5.0).to_f
+      retry_attempts = uri.query_params.fetch("retry_attempts", 1).to_i
+      retry_delay = uri.query_params.fetch("retry_delay", 0.2).to_f
+
+      # default is 1, but we want to be able to use 25 minimum
+      max_idle_pool_size = uri.query_params.fetch("max_idle_pool_size", 25).to_i
+
       @pool = DB::Pool.new(
+        initial_pool_size: initial_pool_size,
+        max_pool_size: max_pool_size,
         max_idle_pool_size: max_idle_pool_size,
-      ) { Connection.new(uri) }
+        checkout_timeout: checkout_timeout,
+        retry_attempts: retry_attempts,
+        retry_delay: retry_delay,
+      ) do
+        Connection.new(uri)
+      end
     end
 
     # All Redis commands invoked on the client check out a connection from the

--- a/src/connection.cr
+++ b/src/connection.cr
@@ -30,6 +30,15 @@ module Redis
       socket = TCPSocket.new(host, port)
       socket.sync = false
 
+      # TCP keepalive settings
+      # allow disabling keepalive
+      if uri.query_params.fetch("keepalive", false)
+        socket.keepalive = true
+        socket.tcp_keepalive_count = uri.query_params.fetch("keepalive_count", 3).to_i
+        socket.tcp_keepalive_idle = uri.query_params.fetch("keepalive_idle", 60).to_i
+        socket.tcp_keepalive_interval = uri.query_params.fetch("keepalive_interval", 30).to_i
+      end
+
       # Check whether we should use SSL
       if uri.scheme == "rediss"
         socket = OpenSSL::SSL::Socket::Client.new(socket)


### PR DESCRIPTION
To help with Redis connection stability issues and connection pool customisation, these changes allow **all** settings to be configured.
We also keep some reasonable defaults to get folk started.
Docs updated to reflect all the options.