### PR TITLE
Fix type errors in Commands::Streams

### DIFF
--- a/src/commands/stream.cr
+++ b/src/commands/stream.cr
@@ -87,7 +87,7 @@ module Redis::Commands::Stream
 
   # Return the entries in the given stream between the `start` and `end` ids.
   # If `count` is provided, Redis will return only that number of entries.
-  def xrange(key : String, start min, end max, count : String | Int | Nil = nil)
+  def xrange(key : String, start min : String, end max : String, count : String | Int | Nil = nil)
     command = {"xrange", key, min, max}
     if count
       command += {"count", count.to_s}

--- a/src/commands/stream.cr
+++ b/src/commands/stream.cr
@@ -87,10 +87,10 @@ module Redis::Commands::Stream
 
   # Return the entries in the given stream between the `start` and `end` ids.
   # If `count` is provided, Redis will return only that number of entries.
-  def xrange(key : String, start min, end max, count = nil)
+  def xrange(key : String, start min, end max, count : String | Int | Nil = nil)
     command = {"xrange", key, min, max}
     if count
-      command += {"count", count}
+      command += {"count", count.to_s}
     end
 
     run command

--- a/src/commands/stream.cr
+++ b/src/commands/stream.cr
@@ -41,7 +41,7 @@ module Redis::Commands::Stream
   # ```
   # redis.xadd "my-stream", "*", {"name" => "foo", "id" => UUID.random.to_s}
   # ```
-  def xadd(key : String, id : String, data : Hash(String, String))
+  def xadd(key : String, id : String, data : ::Hash(String, String))
     xadd key, id, maxlen: nil, data: data
   end
 
@@ -56,7 +56,7 @@ module Redis::Commands::Stream
   # ```
   # redis.xadd "my-stream", "*", {"name" => "foo", "id" => UUID.random.to_s}
   # ```
-  def xadd(key : String, id : String, maxlen, data : Hash(String, String))
+  def xadd(key : String, id : String, maxlen, data : ::Hash(String, String))
     command = Array(String).new(initial_capacity: data.size * 2 + 3)
     command << "xadd" << key
     command << "maxlen" << maxlen if maxlen


### PR DESCRIPTION
I was running into some type errors on `xadd` and `xrange`  like:

```sh
In lib/redis/src/commands/stream.cr:59:54

 59 | def xadd(key : String, id : String, maxlen, data : Hash(String, String))
                                                         ^
Error: Redis::Commands::Hash is not a generic type, it's a module
```

This PR adds fixes for those two commands.