### PR TITLE
fix Error: can't infer the type of instance variable '@uri' of Redis:…

### DIFF
--- a/src/connection.cr
+++ b/src/connection.cr
@@ -24,7 +24,7 @@ module Redis
     # SSL connections require specifying the `rediss://` scheme.
     # Password authentication uses the URI password.
     # DB selection uses the URI path.
-    def initialize(@uri = URI.parse("redis:///"))
+    def initialize(@uri : URI = URI.parse("redis:///"))
       host = uri.host.presence || "localhost"
       port = uri.port || 6379
       socket = TCPSocket.new(host, port)


### PR DESCRIPTION
…:Connection

In one of my projects, I recently encountered this error:

```
Showing last frame. Use --error-trace for full trace.

In lib/redis/src/connection.cr:363:22

 363 | initialize @uri
                  ^---
Error: can't infer the type of instance variable '@uri' of Redis::Connection

Could you add a type annotation like this

    class Redis::Connection
      @uri : Type
    end

replacing `Type` with the expected type of `@uri`?
```

I don't understand where this comes from, as it was working well before. It's likely due to some change in third-party libraries. Nonetheless, this small change fixed it. Please review the PR.