### PR TITLE
Fix deprecation warnings in Crystal v1.19

### DIFF
--- a/src/cluster.cr
+++ b/src/cluster.cr
@@ -233,7 +233,7 @@ module Redis
         # it before checking.
         command = command.downcase if command =~ /[A-Z]/
 
-        started_at = Time.monotonic
+        started_at = instant_time
         if READ_ONLY_COMMANDS.includes?(command)
           read_pool_for(key)
         else
@@ -241,7 +241,7 @@ module Redis
         end.checkout do |connection|
           connection.run(full_command)
         end.tap do
-          LOG.debug &.emit(command: full_command.join(' '), duration: (Time.monotonic - started_at).total_seconds)
+          LOG.debug &.emit(command: full_command.join(' '), duration: (instant_time - started_at).total_seconds)
         end
       else
         raise Error.new("No key was specified for this command, so the cluster driver cannot route it to an appropriate Redis shard. A cluster-specific method must be added to handle cases like these until a generalized solution is added.")

--- a/src/commands.cr
+++ b/src/commands.cr
@@ -482,5 +482,13 @@ module Redis
     def wait(numreplicas replica_count : Int | String, timeout : Int | String)
       run({"wait", replica_count.to_s, timeout.to_s})
     end
+
+    private def instant_time
+      {%if compare_versions(Crystal::VERSION, "1.19.0") >= 0 %}
+        Time.instant
+      {% else %}
+        Time.monotonic
+      {% end %}
+    end
   end
 end

--- a/src/connection.cr
+++ b/src/connection.cr
@@ -228,7 +228,7 @@ module Redis
     # run({"set", "foo", "bar"})
     # ```
     def run(command, retries = 5) : Value
-      start = Time.monotonic
+      start = instant_time
 
       loop do
         @writer.encode command
@@ -253,7 +253,7 @@ module Redis
       ensure
         @log.debug &.emit "redis",
           command: command.join(' '),
-          duration_ms: (Time.monotonic - start).total_milliseconds
+          duration_ms: (instant_time - start).total_milliseconds
       end
     rescue ex : IO::Error | Redis::ReadOnly
       raise DB::PoolResourceLost.new(self, cause: ex)

--- a/src/transaction.cr
+++ b/src/transaction.cr
@@ -37,13 +37,13 @@ module Redis
     end
 
     def exec
-      start = Time.monotonic
+      start = instant_time
       begin
         finish("exec").as(Array(Value)?)
       ensure
         @connection.log.debug &.emit "exec",
           commands: @command_count,
-          duration_ms: (Time.monotonic - start).total_milliseconds
+          duration_ms: (instant_time - start).total_milliseconds
         @status = :committed
       end
     end


### PR DESCRIPTION
`Time.monotonic` is deprecated since Crystal v1.19.